### PR TITLE
Correct case of file name

### DIFF
--- a/Sources/config.yaml
+++ b/Sources/config.yaml
@@ -1,4 +1,4 @@
 sources:
-  - Moirai.glyphs
+  - moirai.glyphs
 familyName: "Moirai One"
 buildOTF: false


### PR DESCRIPTION
The file is called `moirai.glyphs`, not `Moirai.glyphs`; this doesn't matter on MacOS, which has a case-insensitive filesystem, but it means it won't build on Linux.